### PR TITLE
MQTT Test: Add FRTest_GenerateRandInt and MqttTestGetTimeMs.

### DIFF
--- a/config_template/test_param_config_template.h
+++ b/config_template/test_param_config_template.h
@@ -51,6 +51,21 @@
  */
 
 /**
+ * @brief The MQTT client identifier used in MQTT test.  Each client identifier
+ * must be unique; so edit as required to ensure that no two clients connecting to
+ * the same broker use the same client identifier.
+ *
+ * #define MQTT_TEST_CLIENT_IDENTIFIER				"insert here."
+ */
+
+ /**
+ * @brief Network buffer size specified in bytes. Must be large enough to hold the maximum
+ * anticipated MQTT payload.
+ *
+ * #define MQTT_TEST_NETWORK_BUFFER_SIZE			"insert here."
+ */
+
+/**
  * @brief Root certificate of the IoT Core.
  *
  * @note This certificate should be PEM-encoded.

--- a/src/common/platform_function.h
+++ b/src/common/platform_function.h
@@ -85,4 +85,11 @@ void * FRTest_MemoryAlloc( size_t size );
  */
 void FRTest_MemoryFree( void * ptr );
 
+/**
+ * @brief To generate random number in INT format.
+ *
+ * @return A random number.
+ */
+int FRTest_GenerateRandInt();
+
 #endif /* PLATFORM_FUNCTION_H */

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -45,6 +45,13 @@
 
 /*-----------------------------------------------------------*/
 
+/* Wrapper to backward compatible for old version coreMQTT. */
+#if MQTT_TEST_VERSION <= ( 120 )
+    #define lastPacketTxTime    ( lastPacketTime )
+#endif /* MQTT_TEST_VERSION <= ( 120 ) */
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Length of MQTT server host name.
  */
@@ -119,7 +126,7 @@
 /**
  * @brief Client identifier for use in LWT tests.
  */
-#define TEST_CLIENT_IDENTIFIER_LWT              CLIENT_IDENTIFIER "-LWT"
+#define TEST_CLIENT_IDENTIFIER_LWT              MQTT_TEST_CLIENT_IDENTIFIER "-LWT"
 
 /**
  * @brief Length of LWT client identifier.
@@ -167,15 +174,13 @@
 
 /*-----------------------------------------------------------*/
 
-#if ( MQTT_TEST_ENABLED == 1 )
-    #ifndef MQTT_SERVER_ENDPOINT
-        #error "Please define MQTT_SERVER_ENDPOINT"
-    #endif
-    
-    #ifndef MQTT_SERVER_PORT
-        #error "Please define MQTT_SERVER_PORT"
-    #endif
-#endif /* if ( MQTT_TEST_ENABLED == 1 ) */
+#ifndef MQTT_SERVER_ENDPOINT
+    #error "Please define MQTT_SERVER_ENDPOINT"
+#endif
+
+#ifndef MQTT_SERVER_PORT
+    #error "Please define MQTT_SERVER_PORT"
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -394,7 +399,7 @@ static void establishMqttSession( MQTTContext_t * pContext,
         /* Initialize MQTT library. */
         TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Init( pContext,
                                                    &transport,
-                                                   MqttTestGetTimeMs,
+                                                   testParam->pGetTimeMs,
                                                    eventCallback,
                                                    &networkBuffer ) );
     }
@@ -420,7 +425,7 @@ static void establishMqttSession( MQTTContext_t * pContext,
             snprintf( clientIdBuffer,
                       sizeof( clientIdBuffer ),
                       "%d%s", clientIdRandNumber,
-                      TEST_CLIENT_IDENTIFIER );
+					  MQTT_TEST_CLIENT_IDENTIFIER );
         connectInfo.pClientIdentifier = clientIdBuffer;
     }
 

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -36,7 +36,6 @@
 #include "demo_config.h"
 #include "core_mqtt.h"
 #include "core_mqtt_state.h"
-#include "clock.h"
 #include "unity.h"
 #include "unity_fixture.h"
 
@@ -90,12 +89,12 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_TOPIC                         CLIENT_IDENTIFIER "/iot/integration/test"
+#define TEST_MQTT_TOPIC                         MQTT_TEST_CLIENT_IDENTIFIER "/iot/integration/test"
 
 /**
  * @brief Sample topic filter to test MQTT retainted message.
  */
-#define TEST_MQTT_RETAIN_TOPIC                  CLIENT_IDENTIFIER "/iot/integration/testretain"
+#define TEST_MQTT_RETAIN_TOPIC                  MQTT_TEST_CLIENT_IDENTIFIER "/iot/integration/testretain"
 
 /**
  * @brief Length of sample topic filter.
@@ -105,7 +104,7 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_LWT_TOPIC                     CLIENT_IDENTIFIER "/iot/integration/test/lwt"
+#define TEST_MQTT_LWT_TOPIC                     MQTT_TEST_CLIENT_IDENTIFIER "/iot/integration/test/lwt"
 
 /**
  * @brief Length of sample topic filter.
@@ -113,14 +112,9 @@
 #define TEST_MQTT_LWT_TOPIC_LENGTH              ( sizeof( TEST_MQTT_LWT_TOPIC ) - 1 )
 
 /**
- * @brief Client identifier for MQTT session in the tests.
- */
-#define TEST_CLIENT_IDENTIFIER                  CLIENT_IDENTIFIER
-
-/**
  * @brief Length of the client identifier.
  */
-#define TEST_CLIENT_IDENTIFIER_LENGTH           ( sizeof( TEST_CLIENT_IDENTIFIER ) - 1u )
+#define TEST_CLIENT_IDENTIFIER_LENGTH           ( sizeof( MQTT_TEST_CLIENT_IDENTIFIER ) - 1u )
 
 /**
  * @brief Client identifier for use in LWT tests.
@@ -378,7 +372,7 @@ static void establishMqttSession( MQTTContext_t * pContext,
     assert( pContext != NULL );
 
     /* The network buffer must remain valid for the lifetime of the MQTT context. */
-    static uint8_t buffer[ NETWORK_BUFFER_SIZE ];
+    static uint8_t buffer[ MQTT_TEST_NETWORK_BUFFER_SIZE ];
 
     /* Buffer for storing client ID with random integer.
      * Note: Size value is chosen to accommodate both LWT and non-LWT client ID
@@ -388,7 +382,7 @@ static void establishMqttSession( MQTTContext_t * pContext,
 
     /* Fill the values for network buffer. */
     networkBuffer.pBuffer = buffer;
-    networkBuffer.size = NETWORK_BUFFER_SIZE;
+    networkBuffer.size = MQTT_TEST_NETWORK_BUFFER_SIZE;
 
     transport.pNetworkContext = pNetworkContext;
     transport.send = testParam.pTransport->send;
@@ -400,7 +394,7 @@ static void establishMqttSession( MQTTContext_t * pContext,
         /* Initialize MQTT library. */
         TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_Init( pContext,
                                                    &transport,
-                                                   Clock_GetTimeMs,
+                                                   MqttTestGetTimeMs,
                                                    eventCallback,
                                                    &networkBuffer ) );
     }
@@ -749,8 +743,6 @@ static MQTTStatus_t publishToTopic( MQTTContext_t * pContext,
  */
 TEST_SETUP( MqttTest )
 {
-    struct timespec tp;
-
     /* Reset file-scoped global variables. */
     receivedSubAck = false;
     receivedUnsubAck = false;
@@ -764,14 +756,8 @@ TEST_SETUP( MqttTest )
     packetTypeForDisconnection = MQTT_PACKET_TYPE_INVALID;
     memset( &incomingInfo, 0u, sizeof( MQTTPublishInfo_t ) );
 
-    /* Get current time to seed pseudo random number generator. */
-    ( void ) clock_gettime( CLOCK_REALTIME, &tp );
-
-    /* Seed pseudo random number generator with nanoseconds. */
-    srand( tp.tv_nsec );
-
     /* Generate a random number to use in the client identifier. */
-    clientIdRandNumber = ( rand() % ( MAX_RAND_NUMBER_FOR_CLIENT_ID + 1u ) );
+    clientIdRandNumber = ( FRTest_GenerateRandInt() % ( MAX_RAND_NUMBER_FOR_CLIENT_ID + 1u ) );
 
     /* Establish a TCP connection with the server endpoint, then
      * establish TLS session on top of TCP connection. */
@@ -1003,7 +989,7 @@ TEST( MqttTest, MQTT_Connect_LWT )
  */
 TEST( MqttTest, MQTT_ProcessLoop_KeepAlive )
 {
-    uint32_t connectPacketTime = context.lastPacketTime;
+    uint32_t connectPacketTime = context.lastPacketTxTime;
     uint32_t elapsedTime = 0;
 
     TEST_ASSERT_EQUAL( 0, context.pingReqSendTimeMs );
@@ -1013,9 +999,9 @@ TEST( MqttTest, MQTT_ProcessLoop_KeepAlive )
     TEST_ASSERT_EQUAL( MQTTSuccess, MQTT_ProcessLoop( &context, MQTT_PROCESS_LOOP_TIMEOUT_MS ) );
 
     TEST_ASSERT_NOT_EQUAL( 0, context.pingReqSendTimeMs );
-    TEST_ASSERT_NOT_EQUAL( connectPacketTime, context.lastPacketTime );
+    TEST_ASSERT_NOT_EQUAL( connectPacketTime, context.lastPacketTxTime );
     /* Test that the ping was sent within 1.5 times the keep alive interval. */
-    elapsedTime = context.lastPacketTime - connectPacketTime;
+    elapsedTime = context.lastPacketTxTime - connectPacketTime;
     TEST_ASSERT_LESS_OR_EQUAL( MQTT_KEEP_ALIVE_INTERVAL_SECONDS * 1500, elapsedTime );
 }
 

--- a/src/mqtt/mqtt_test.h
+++ b/src/mqtt/mqtt_test.h
@@ -51,6 +51,13 @@ typedef struct MqttTestParam
 void SetupMqttTestParam( MqttTestParam_t * pTestParam );
 
 /**
+ * @brief Customers need to implement this function for MQTT test to set 
+ * MQTTGetCurrentTimeFunc_t in MQTT_Init. This should be an Application 
+ * provided function to query the current time in milliseconds.
+ */
+uint32_t MqttTestGetTimeMs( void );
+
+/**
  * @brief Run MQTT test. This function should be called after calling `SetupMqttTest()`.
  *
  * @return Negative value if the transport test execution config is not set. Otherwise,

--- a/src/mqtt/mqtt_test.h
+++ b/src/mqtt/mqtt_test.h
@@ -29,6 +29,17 @@
 
 #include "transport_interface.h"
 #include "network_connection.h"
+#include "core_mqtt.h"
+
+#if !defined MQTT_LIBRARY_VERSION
+    #error "Can't get current MQTT library version"
+#else
+    #if MQTT_LIBRARY_VERSION == "v1.2.0"
+        #define MQTT_TEST_VERSION    ( 120 )
+    #else
+        #define MQTT_TEST_VERSION    ( 121 )
+    #endif /* MQTT_LIBRARY_VERSION == "v1.2.0" */
+#endif /* !defined MQTT_LIBRARY_VERSION */
 
 typedef struct MqttTestParam
 {
@@ -38,6 +49,7 @@ typedef struct MqttTestParam
     void * pNetworkCredentials;
     void * pNetworkContext;
     void * pSecondNetworkContext;
+    MQTTGetCurrentTimeFunc_t pGetTimeMs;
 } MqttTestParam_t;
 
 /**
@@ -49,13 +61,6 @@ typedef struct MqttTestParam
  *
  */
 void SetupMqttTestParam( MqttTestParam_t * pTestParam );
-
-/**
- * @brief Customers need to implement this function for MQTT test to set 
- * MQTTGetCurrentTimeFunc_t in MQTT_Init. This should be an Application 
- * provided function to query the current time in milliseconds.
- */
-uint32_t MqttTestGetTimeMs( void );
 
 /**
  * @brief Run MQTT test. This function should be called after calling `SetupMqttTest()`.

--- a/src/ota/ota_pal_test.c
+++ b/src/ota/ota_pal_test.c
@@ -131,7 +131,7 @@ TEST_GROUP_RUNNER( Full_OTA_PAL )
 TEST( Full_OTA_PAL, otaPal_CloseFile_ValidSignature )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
     int16_t bytesWritten;
 
     /* We use a dummy file name here because closing the system designated bootable
@@ -169,7 +169,7 @@ TEST( Full_OTA_PAL, otaPal_CloseFile_ValidSignature )
 TEST( Full_OTA_PAL, otaPal_CloseFile_InvalidSignatureBlockWritten )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
     int16_t bytesWritten;
 
     /* Create a local file using the PAL. */
@@ -209,7 +209,7 @@ TEST( Full_OTA_PAL, otaPal_CloseFile_InvalidSignatureBlockWritten )
 TEST( Full_OTA_PAL, otaPal_CloseFile_InvalidSignatureNoBlockWritten )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
 
     /* Create a local file using the PAL. */
     xOtaFile.pFilePath = ( uint8_t * ) OTA_PAL_FIRMWARE_FILE;
@@ -572,7 +572,7 @@ TEST( Full_OTA_PAL, otaPal_SetPlatformImageState_AbortImageState )
 TEST( Full_OTA_PAL, otaPal_GetPlatformImageState_InvalidImageStateFromFileCloseFailure )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
     OtaPalImageState_t ePalImageState = OtaPalImageStateUnknown;
     int16_t bytesWritten;
 


### PR DESCRIPTION
Patches includes:
1. Move rand() related function to platform header file
    - FRTest_GenerateRandInt
2. Add MqttTestGetTimeMs to mqtt_test.h
    - Used for MQTT_Init. Customers need to provide this function.
3. Fix Mqtt/OTA PAL Test compilation for LTS 2.0 libraries