### PR TITLE
MQTT Test: Add FRTest_GenerateRandInt and MqttTestGetTimeMs.

### DIFF
--- a/config_template/test_param_config_template.h
+++ b/config_template/test_param_config_template.h
@@ -51,6 +51,21 @@
  */
 
 /**
+ * @brief The MQTT client identifier used in MQTT test.  Each client identifier
+ * must be unique; so edit as required to ensure that no two clients connecting to
+ * the same broker use the same client identifier.
+ *
+ * #define MQTT_TEST_CLIENT_IDENTIFIER				"insert here."
+ */
+
+ /**
+ * @brief Network buffer size specified in bytes. Must be large enough to hold the maximum
+ * anticipated MQTT payload.
+ *
+ * #define MQTT_TEST_NETWORK_BUFFER_SIZE			"insert here."
+ */
+
+/**
  * @brief Root certificate of the IoT Core.
  *
  * @note This certificate should be PEM-encoded.

--- a/src/common/platform_function.h
+++ b/src/common/platform_function.h
@@ -85,4 +85,11 @@ void * FRTest_MemoryAlloc( size_t size );
  */
 void FRTest_MemoryFree( void * ptr );
 
+/**
+ * @brief To generate random number in INT format.
+ *
+ * @return A random number.
+ */
+int FRTest_GenerateRandInt();
+
 #endif /* PLATFORM_FUNCTION_H */

--- a/src/mqtt/mqtt_test.h
+++ b/src/mqtt/mqtt_test.h
@@ -29,6 +29,17 @@
 
 #include "transport_interface.h"
 #include "network_connection.h"
+#include "core_mqtt.h"
+
+#if !defined MQTT_LIBRARY_VERSION
+    #error "Can't get current MQTT library version"
+#else
+    #if MQTT_LIBRARY_VERSION == "v1.2.0"
+        #define MQTT_TEST_VERSION    ( 120 )
+    #else
+        #define MQTT_TEST_VERSION    ( 121 )
+    #endif /* MQTT_LIBRARY_VERSION == "v1.2.0" */
+#endif /* !defined MQTT_LIBRARY_VERSION */
 
 typedef struct MqttTestParam
 {
@@ -38,6 +49,7 @@ typedef struct MqttTestParam
     void * pNetworkCredentials;
     void * pNetworkContext;
     void * pSecondNetworkContext;
+    MQTTGetCurrentTimeFunc_t pGetTimeMs;
 } MqttTestParam_t;
 
 /**


### PR DESCRIPTION
Patches includes:
1. Move rand() related function to platform header file
    - FRTest_GenerateRandInt
2. Add MqttTestGetTimeMs to MqttTestParam_t in mqtt_test.h
    - Used for MQTT_Init. Customers need to provide this function.
3. Fix Mqtt Test compilation for LTS 2.0 libraries