### PR TITLE
MQTT Test: Add FRTest_GenerateRandInt and MqttTestGetTimeMs.

### DIFF
--- a/config_template/test_param_config_template.h
+++ b/config_template/test_param_config_template.h
@@ -51,6 +51,22 @@
  */
 
 /**
+ * @brief The IoT Thing name for the device for OTA test and MQTT test.
+ * From https://docs.aws.amazon.com/iot/latest/developerguide/iot-thing-management.html,
+ * MQTT_CLIENT_IDENTIFIER is different from IOT_THING_NAME. But we use IOT_THING_NAME
+ * to be MQTT_CLIENT_IDENTIFIER here in MQTT Test and OTA E2E test.
+ *
+ * #define IOT_THING_NAME  "PLACE_HOLDER"
+ */
+
+ /**
+ * @brief Network buffer size specified in bytes. Must be large enough to hold the maximum
+ * anticipated MQTT payload.
+ *
+ * #define MQTT_TEST_NETWORK_BUFFER_SIZE  ( 5000 )
+ */
+
+/**
  * @brief Root certificate of the IoT Core.
  *
  * @note This certificate should be PEM-encoded.
@@ -279,12 +295,6 @@
  * This label has to be defined if PKCS11_TEST_JITP_CODEVERIFY_ROOT_CERT_SUPPORTED is set to 1.
  *
  * #define PKCS11_TEST_LABEL_ROOT_CERTIFICATE    pkcs11configLABEL_ROOT_CERTIFICATE
- */
-
-/**
- * @brief The IoT Thing name for the device for OTA test.
- *
- * #define IOT_THING_NAME  "PLACE_HOLDER"
  */
 
 /**

--- a/config_template/test_param_config_template.h
+++ b/config_template/test_param_config_template.h
@@ -51,12 +51,9 @@
  */
 
 /**
- * @brief The IoT Thing name for the device for OTA test and MQTT test.
- * From https://docs.aws.amazon.com/iot/latest/developerguide/iot-thing-management.html,
- * MQTT_CLIENT_IDENTIFIER is different from IOT_THING_NAME. But we use IOT_THING_NAME
- * to be MQTT_CLIENT_IDENTIFIER here in MQTT Test and OTA E2E test.
+ * @brief The client identifier for MQTT test.
  *
- * #define IOT_THING_NAME  "PLACE_HOLDER"
+ * #define MQTT_TEST_CLIENT_IDENTIFIER    "PLACE_HOLDER"
  */
 
  /**
@@ -295,6 +292,12 @@
  * This label has to be defined if PKCS11_TEST_JITP_CODEVERIFY_ROOT_CERT_SUPPORTED is set to 1.
  *
  * #define PKCS11_TEST_LABEL_ROOT_CERTIFICATE    pkcs11configLABEL_ROOT_CERTIFICATE
+ */
+
+/**
+ * @brief The IoT Thing name for the device for OTA test.
+ *
+ * #define IOT_THING_NAME  "PLACE_HOLDER"
  */
 
 /**

--- a/src/common/platform_function.h
+++ b/src/common/platform_function.h
@@ -85,4 +85,11 @@ void * FRTest_MemoryAlloc( size_t size );
  */
 void FRTest_MemoryFree( void * ptr );
 
+/**
+ * @brief To generate random number in INT format.
+ *
+ * @return A random number.
+ */
+int FRTest_GenerateRandInt();
+
 #endif /* PLATFORM_FUNCTION_H */

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -89,12 +89,12 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_TOPIC                         IOT_THING_NAME "/iot/integration/test"
+#define TEST_MQTT_TOPIC                         MQTT_TEST_CLIENT_IDENTIFIER "/iot/integration/test"
 
 /**
  * @brief Sample topic filter to test MQTT retainted message.
  */
-#define TEST_MQTT_RETAIN_TOPIC                  IOT_THING_NAME "/iot/integration/testretain"
+#define TEST_MQTT_RETAIN_TOPIC                  MQTT_TEST_CLIENT_IDENTIFIER "/iot/integration/testretain"
 
 /**
  * @brief Length of sample topic filter.
@@ -104,7 +104,7 @@
 /**
  * @brief Sample topic filter to subscribe to.
  */
-#define TEST_MQTT_LWT_TOPIC                     IOT_THING_NAME "/iot/integration/test/lwt"
+#define TEST_MQTT_LWT_TOPIC                     MQTT_TEST_CLIENT_IDENTIFIER "/iot/integration/test/lwt"
 
 /**
  * @brief Length of sample topic filter.
@@ -114,12 +114,12 @@
 /**
  * @brief Length of the client identifier.
  */
-#define TEST_CLIENT_IDENTIFIER_LENGTH           ( sizeof( IOT_THING_NAME ) - 1u )
+#define TEST_CLIENT_IDENTIFIER_LENGTH           ( sizeof( MQTT_TEST_CLIENT_IDENTIFIER ) - 1u )
 
 /**
  * @brief Client identifier for use in LWT tests.
  */
-#define TEST_CLIENT_IDENTIFIER_LWT              IOT_THING_NAME "-LWT"
+#define TEST_CLIENT_IDENTIFIER_LWT              MQTT_TEST_CLIENT_IDENTIFIER "-LWT"
 
 /**
  * @brief Length of LWT client identifier.
@@ -420,7 +420,7 @@ static void establishMqttSession( MQTTContext_t * pContext,
             snprintf( clientIdBuffer,
                       sizeof( clientIdBuffer ),
                       "%d%s", clientIdRandNumber,
-                      IOT_THING_NAME );
+                      MQTT_TEST_CLIENT_IDENTIFIER );
         connectInfo.pClientIdentifier = clientIdBuffer;
     }
 

--- a/src/mqtt/mqtt_test.h
+++ b/src/mqtt/mqtt_test.h
@@ -29,6 +29,7 @@
 
 #include "transport_interface.h"
 #include "network_connection.h"
+#include "core_mqtt.h"
 
 typedef struct MqttTestParam
 {
@@ -38,6 +39,7 @@ typedef struct MqttTestParam
     void * pNetworkCredentials;
     void * pNetworkContext;
     void * pSecondNetworkContext;
+    MQTTGetCurrentTimeFunc_t pGetTimeMs; /**< @brief The getTimeFunction for MQTT_Init API. */
 } MqttTestParam_t;
 
 /**


### PR DESCRIPTION
Patches includes:

1. Move rand() related function to platform header file
    - FRTest_GenerateRandInt
2. Add MqttTestGetTimeMs to MqttTestParam_t in mqtt_test.h
    - Used for MQTT_Init. Customers need to provide this function.