### PR TITLE
OTA PAL Test: Replace Sig256_t with Sig_t for LTS 2.0 udpate.

### DIFF
--- a/src/ota/ota_pal_test.c
+++ b/src/ota/ota_pal_test.c
@@ -131,7 +131,7 @@ TEST_GROUP_RUNNER( Full_OTA_PAL )
 TEST( Full_OTA_PAL, otaPal_CloseFile_ValidSignature )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
     int16_t bytesWritten;
 
     /* We use a dummy file name here because closing the system designated bootable
@@ -169,7 +169,7 @@ TEST( Full_OTA_PAL, otaPal_CloseFile_ValidSignature )
 TEST( Full_OTA_PAL, otaPal_CloseFile_InvalidSignatureBlockWritten )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
     int16_t bytesWritten;
 
     /* Create a local file using the PAL. */
@@ -209,7 +209,7 @@ TEST( Full_OTA_PAL, otaPal_CloseFile_InvalidSignatureBlockWritten )
 TEST( Full_OTA_PAL, otaPal_CloseFile_InvalidSignatureNoBlockWritten )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
 
     /* Create a local file using the PAL. */
     xOtaFile.pFilePath = ( uint8_t * ) OTA_PAL_FIRMWARE_FILE;
@@ -244,7 +244,7 @@ TEST( Full_OTA_PAL, otaPal_CloseFile_NonexistingCodeSignerCertificate )
 {
     #if ( OTA_PAL_USE_FILE_SYSTEM == 1 )
         OtaPalStatus_t xOtaStatus;
-        Sig256_t xSig = { 0 };
+        Sig_t xSig = { 0 };
         int16_t bytesWritten;
 
         memset( &xOtaFile, 0, sizeof( xOtaFile ) );
@@ -572,7 +572,7 @@ TEST( Full_OTA_PAL, otaPal_SetPlatformImageState_AbortImageState )
 TEST( Full_OTA_PAL, otaPal_GetPlatformImageState_InvalidImageStateFromFileCloseFailure )
 {
     OtaPalStatus_t xOtaStatus;
-    Sig256_t xSig = { 0 };
+    Sig_t xSig = { 0 };
     OtaPalImageState_t ePalImageState = OtaPalImageStateUnknown;
     int16_t bytesWritten;
 


### PR DESCRIPTION
Fix OTA PAL Test compilation for LTS 2.0 libraries
- Replace Sig256_t with Sig_t for [OTA commit](https://github.com/aws/ota-for-aws-iot-embedded-sdk/commit/6ccb758fb9da5fe5da965036c3af96c7329cc453).