### PR TITLE
Check incomingInfo by length to avoid accessing NULL pointer.

### DIFF
--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -982,9 +982,11 @@ TEST( MqttTest, MQTT_Subscribe_Publish_With_Qos_1 )
             /* Timeout. */
             break;
         }
-        else if( ( receivedPubAck != 0 ) && ( incomingInfo.topicNameLength == TEST_MQTT_TOPIC_LENGTH ) )
+        else if( ( receivedPubAck != 0 ) && ( incomingInfo.topicNameLength > 0 ) )
         {
             /* Both the PUBACK and the incoming publish have been received. */
+            /* "incomingInfo.topicNameLength > 0" means we got a publish message from MQTT broker.
+             * We compare message's content/length after breaking loop. */
             break;
         }
         else
@@ -1109,9 +1111,11 @@ TEST( MqttTest, MQTT_Connect_LWT )
             /* Timeout. */
             break;
         }
-        else if( incomingInfo.topicNameLength == TEST_MQTT_LWT_TOPIC_LENGTH )
+        else if( incomingInfo.topicNameLength > 0 )
         {
             /* Some data was received on the LWT topic. */
+            /* "incomingInfo.topicNameLength > 0" means we got a publish message from MQTT broker.
+             * We compare message's content/length after breaking loop. */
             break;
         }
         else

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -1109,7 +1109,7 @@ TEST( MqttTest, MQTT_Connect_LWT )
             /* Timeout. */
             break;
         }
-        else if( strncmp( incomingInfo.pTopicName, TEST_MQTT_LWT_TOPIC, TEST_MQTT_LWT_TOPIC_LENGTH ) == 0 )
+        else if( incomingInfo.topicNameLength == TEST_MQTT_LWT_TOPIC_LENGTH )
         {
             /* Some data was received on the LWT topic. */
             break;

--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -949,7 +949,7 @@ TEST( MqttTest, MQTT_Subscribe_Publish_With_Qos_1 )
         {
             /* Nothing to do. */
         }
-    }while( ( xMQTTStatus == MQTTSuccess ) || ( xMQTTStatus == MQTTNeedMoreBytes ) );
+    } while( ( xMQTTStatus == MQTTSuccess ) || ( xMQTTStatus == MQTTNeedMoreBytes ) );
 
     TEST_ASSERT_TRUE( ( xMQTTStatus == MQTTSuccess ) || ( xMQTTStatus == MQTTNeedMoreBytes ) );
     TEST_ASSERT_TRUE( receivedSubAck );
@@ -982,7 +982,7 @@ TEST( MqttTest, MQTT_Subscribe_Publish_With_Qos_1 )
             /* Timeout. */
             break;
         }
-        else if( ( receivedPubAck != 0 ) && ( strncmp( TEST_MQTT_TOPIC, incomingInfo.pTopicName, TEST_MQTT_TOPIC_LENGTH ) == 0 ) )
+        else if( ( receivedPubAck != 0 ) && ( incomingInfo.topicNameLength == TEST_MQTT_TOPIC_LENGTH ) )
         {
             /* Both the PUBACK and the incoming publish have been received. */
             break;
@@ -991,7 +991,7 @@ TEST( MqttTest, MQTT_Subscribe_Publish_With_Qos_1 )
         {
             /* Nothing to do. */
         }
-    }while( ( xMQTTStatus == MQTTSuccess ) || ( xMQTTStatus == MQTTNeedMoreBytes ) );
+    } while( ( xMQTTStatus == MQTTSuccess ) || ( xMQTTStatus == MQTTNeedMoreBytes ) );
 
     TEST_ASSERT_TRUE( ( xMQTTStatus == MQTTSuccess ) || ( xMQTTStatus == MQTTNeedMoreBytes ) );
     /* Make sure we have received PUBACK response. */


### PR DESCRIPTION
Fix MQTT test case: 
- Check incomingInfo by length to avoid accessing NULL pointer.