### PR TITLE
Update to include P3 release, 202211.00, and new FreeRTOS-Libraries-Integration-Tests release tag

### DIFF
--- a/version-mappings.yml
+++ b/version-mappings.yml
@@ -5,9 +5,10 @@ mappings:
   - freeRTOSVersion: "202210.00-LTS"
     compatibleTestsVersions:
       - "202210.00"
-  - freeRTOSVersion: "202210.00"
+      - "202210.01"
+  - freeRTOSVersion: "202211.00"
     compatibleTestsVersions:
-      - "202210.00"
+      - "202210.01"
   - freeRTOSVersion: "202012.00-LTS"
     compatibleTestsVersions:
       - "202205.01"


### PR DESCRIPTION
I have updated the old P3 release version number from `202210.00` to `202211.00`, this change depends on the repo being tagged with `202210.01`. IDT looks at the `version-mappings.yml` file based on the release tag of the repo, and checks for the FreeRTOS version. Since 202211.00 is not associated with `202210.00` tests repo tag, we need a new tag.