### PR TITLE
Remove configPirntf in mqtt_test.c

### DIFF
--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -1691,7 +1691,6 @@ TEST( MqttTest, MQTT_SubUnsub_Multiple_Topics )
         /* Reset the PUBACK flag. */
         receivedPubAck = false;
 
-        configPRINTF( ( "%u Entered1", xTaskGetTickCount() ) );
         entryTime = FRTest_GetTimeMs();
         do
         {


### PR DESCRIPTION
Remove configPirntf in mqtt_test.c.
There is no configPrintf in GRI iot-reference-stm32u5. It is a platform dependent function.