### PR TITLE
Fix RSA PKCS11_RSA_GetAttributeValue test

### DIFF
--- a/src/pkcs11/README.md
+++ b/src/pkcs11/README.md
@@ -59,6 +59,8 @@ The following table lists the required test configurations for PKCS #11 tests. T
 |PKCS11_TEST_LABEL_CODE_VERIFICATION_KEY	|The label of the code verification key used in JITP codeverify test.	|
 |PKCS11_TEST_LABEL_JITP_CERTIFICATE	|The label of the JITP certificate used in JITP codeverify test.	|
 |PKCS11_TEST_LABEL_ROOT_CERTIFICATE	|The label of the root certificate used in JITP codeverify test.	|
+|PKCS11_TEST_RSA_CERTIFICATE	|The certificate used to verify RSA preprovision mechanism.	|
+|PKCS11_TEST_RSA_CERTIFICATE_LENGTH	|The certificate length used to verify RSA preprovision mechanism.	|
 
 
 FreeRTOS libraries and reference integrations needs at least one of the key function and one of the key provisioning mechanism supported by the PKCS #11 APIs. The test must enable at least one of the following configurations:
@@ -77,6 +79,7 @@ Pre-provisioned device credential test can not be enabled with other provisionin
 * Enable **PKCS11_TEST_PREPROVISIONED_SUPPORT** and the other provisioning mechanisms must be disabled
 * Only one of the key function, **PKCS11_TEST_RSA_KEY_SUPPORT** or **PKCS11_TEST_EC_KEY_SUPPORT**, enabled
 * Setup the pre-provisioned key labels according to your key function, including **PKCS11_TEST_LABEL_DEVICE_PRIVATE_KEY_FOR_TLS**, **PKCS11_TEST_LABEL_DEVICE_PUBLIC_KEY_FOR_TLS** and **PKCS11_TEST_LABEL_DEVICE_CERTIFICATE_FOR_TLS**. These credentials must exist in the PKCS #11 before running the test.
+* **PKCS11_TEST_RSA_CERTIFICATE** and **PKCS11_TEST_RSA_CERTIFICATE_LENGTH** must be defined before running the test to verify RSA preprovision mechanism.
 
 You may need to run the test several times with different configurations if your implementation support pre-provisioned credentials and other provisioning mechanisms.
 

--- a/src/pkcs11/core_pkcs11_test.c
+++ b/src/pkcs11/core_pkcs11_test.c
@@ -1635,13 +1635,19 @@ static void prvTestRsaGetAttributeValue( provisionMethod_t testProvisionMethod )
     xTemplate.pValue = NULL;
     xTemplate.ulValueLen = 0;
     xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xCertificateHandle, &xTemplate, 1 );
+    if( testProvisionMethod == eProvisionImportPrivateKey )
+    {
     TEST_ASSERT_MESSAGE( ( CERTIFICATE_VALUE_LENGTH == xTemplate.ulValueLen ), "GetAttributeValue returned incorrect length of RSA certificate value" );
+    }
 
     /* Get the certificate value. */
     xTemplate.pValue = xCertificateValue;
     xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xCertificateHandle, &xTemplate, 1 );
     TEST_ASSERT_MESSAGE( ( CKR_OK == xResult ), "Failed to get RSA certificate value" );
+    if( testProvisionMethod == eProvisionImportPrivateKey )
+    {
     TEST_ASSERT_MESSAGE( ( CERTIFICATE_VALUE_LENGTH == xTemplate.ulValueLen ), "GetAttributeValue returned incorrect length of RSA certificate value" );
+    }
 
     if( testProvisionMethod == eProvisionImportPrivateKey )
     {
@@ -1753,6 +1759,8 @@ static void prvTestRsaSign( provisionMethod_t testProvisionMethod )
     if( TEST_PROTECT() )
     {
         #if MBEDTLS_VERSION_NUMBER < 0x03000000
+        if( sizeof( cValidRSAPrivateKey ) > 1 )
+        {
             lMbedTLSResult = mbedtls_pk_parse_key( ( mbedtls_pk_context * ) &xMbedPkContext,
                                                    ( const unsigned char * ) cValidRSAPrivateKey,
                                                    sizeof( cValidRSAPrivateKey ),
@@ -1762,9 +1770,11 @@ static void prvTestRsaSign( provisionMethod_t testProvisionMethod )
 
             lMbedTLSResult = mbedtls_rsa_pkcs1_verify( xMbedPkContext.pk_ctx, NULL, NULL,
                 MBEDTLS_RSA_PUBLIC, MBEDTLS_MD_SHA256, 32, xHashedMessage, xSignature );
-            TEST_ASSERT_MESSAGE( ( 0 == xResult ), "mbedTLS failed to verify RSA signagure." );
-
+            TEST_ASSERT_MESSAGE( ( 0 == xResult ), "mbedTLS failed to verify RSA signature." );
+        }
         #else
+        if( sizeof( cValidRSAPrivateKey ) > 1 )
+        {
             lMbedTLSResult = mbedtls_ctr_drbg_seed( &xDrbgContext, mbedtls_entropy_func, &xEntropyContext, NULL, 0 );
             TEST_ASSERT_MESSAGE( ( 0 == lMbedTLSResult ), "Failed to initialize DRBG" );
 
@@ -1779,7 +1789,7 @@ static void prvTestRsaSign( provisionMethod_t testProvisionMethod )
             lMbedTLSResult = mbedtls_rsa_pkcs1_verify( xMbedPkContext.pk_ctx, MBEDTLS_MD_SHA256,
                 32, xHashedMessage, xSignature );
             TEST_ASSERT_MESSAGE( ( 0 == xResult ), "mbedTLS failed to verify RSA signagure." );
-
+        }
         #endif /* MBEDTLS_VERSION_NUMBER < 0x03000000 */
     }
 

--- a/src/pkcs11/core_pkcs11_test.c
+++ b/src/pkcs11/core_pkcs11_test.c
@@ -56,13 +56,13 @@
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/x509_crt.h"
 
+/* Test configuration includes. */
+#include "test_param_config.h"
+
 /* corePKCS11 test includes. */
 #include "platform_function.h"
 #include "rsa_test_credentials.h"
 #include "ecdsa_test_credentials.h"
-
-/* Test configuration includes. */
-#include "test_param_config.h"
 
 /*-----------------------------------------------------------*/
 
@@ -140,7 +140,7 @@
 /**
  * @brief Test RSA certificate value length.
  */
-#define CERTIFICATE_VALUE_LENGTH        ( 949 )
+#define CERTIFICATE_VALUE_LENGTH        ( RSA_TEST_VALID_CERTIFICATE_LENGTH )
 
 /**
  * @brief EC point length.
@@ -1635,45 +1635,37 @@ static void prvTestRsaGetAttributeValue( provisionMethod_t testProvisionMethod )
     xTemplate.pValue = NULL;
     xTemplate.ulValueLen = 0;
     xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xCertificateHandle, &xTemplate, 1 );
-    if( testProvisionMethod == eProvisionImportPrivateKey )
-    {
+    TEST_ASSERT_MESSAGE( ( CKR_OK == xResult ), "Failed to get RSA certificate value length." );
     TEST_ASSERT_MESSAGE( ( CERTIFICATE_VALUE_LENGTH == xTemplate.ulValueLen ), "GetAttributeValue returned incorrect length of RSA certificate value" );
-    }
 
     /* Get the certificate value. */
     xTemplate.pValue = xCertificateValue;
     xResult = pxGlobalFunctionList->C_GetAttributeValue( xGlobalSession, xCertificateHandle, &xTemplate, 1 );
-    TEST_ASSERT_MESSAGE( ( CKR_OK == xResult ), "Failed to get RSA certificate value" );
-    if( testProvisionMethod == eProvisionImportPrivateKey )
-    {
+    TEST_ASSERT_MESSAGE( ( CKR_OK == xResult ), "Failed to get RSA certificate value." );
     TEST_ASSERT_MESSAGE( ( CERTIFICATE_VALUE_LENGTH == xTemplate.ulValueLen ), "GetAttributeValue returned incorrect length of RSA certificate value" );
+
+    /* Verify the imported certificate. */
+    pucDerObject = FRTest_MemoryAlloc( sizeof( cValidRSACertificate ) );
+    TEST_ASSERT_MESSAGE( pucDerObject != NULL, "Allocate memory for RSA certificate failed." );
+    xDerLen = sizeof( cValidRSACertificate );
+
+    lConversionReturn = convert_pem_to_der( ( const unsigned char * ) cValidRSACertificate,
+                                            sizeof( cValidRSACertificate ),
+                                            pucDerObject,
+                                            &xDerLen );
+
+    if( lConversionReturn == 0 )
+    {
+        lImportKeyCompare = memcmp( xTemplate.pValue, pucDerObject, xTemplate.ulValueLen );
     }
 
-    if( testProvisionMethod == eProvisionImportPrivateKey )
+    /* Free the allocated memory and compare. */
+    FRTest_MemoryFree( pucDerObject );
+    pucDerObject = NULL;
+
+    if( ( lConversionReturn != 0 ) || ( lImportKeyCompare != 0 ) )
     {
-        /* Verify the imported certificate. */
-        pucDerObject = FRTest_MemoryAlloc( sizeof( cValidRSACertificate ) );
-        TEST_ASSERT_MESSAGE( pucDerObject != NULL, "Allocate memory for RSA certificate failed." );
-        xDerLen = sizeof( cValidRSACertificate );
-
-        lConversionReturn = convert_pem_to_der( ( const unsigned char * ) cValidRSACertificate,
-                                                sizeof( cValidRSACertificate ),
-                                                pucDerObject,
-                                                &xDerLen );
-
-        if( lConversionReturn == 0 )
-        {
-            lImportKeyCompare = memcmp( xTemplate.pValue, pucDerObject, xTemplate.ulValueLen );
-        }
-
-        /* Free the allocated memory and compare. */
-        FRTest_MemoryFree( pucDerObject );
-        pucDerObject = NULL;
-
-        if( ( lConversionReturn != 0 ) || ( lImportKeyCompare != 0 ) )
-        {
-            TEST_FAIL_MESSAGE( "Compare imported RSA certificate failed." );
-        }
+        TEST_FAIL_MESSAGE( "Compare imported RSA certificate failed." );
     }
 
     /* Get the private key handle. */
@@ -1759,7 +1751,6 @@ static void prvTestRsaSign( provisionMethod_t testProvisionMethod )
     if( TEST_PROTECT() )
     {
         #if MBEDTLS_VERSION_NUMBER < 0x03000000
-        if( sizeof( cValidRSAPrivateKey ) > 1 )
         {
             lMbedTLSResult = mbedtls_pk_parse_key( ( mbedtls_pk_context * ) &xMbedPkContext,
                                                    ( const unsigned char * ) cValidRSAPrivateKey,
@@ -1773,7 +1764,6 @@ static void prvTestRsaSign( provisionMethod_t testProvisionMethod )
             TEST_ASSERT_MESSAGE( ( 0 == xResult ), "mbedTLS failed to verify RSA signature." );
         }
         #else
-        if( sizeof( cValidRSAPrivateKey ) > 1 )
         {
             lMbedTLSResult = mbedtls_ctr_drbg_seed( &xDrbgContext, mbedtls_entropy_func, &xEntropyContext, NULL, 0 );
             TEST_ASSERT_MESSAGE( ( 0 == lMbedTLSResult ), "Failed to initialize DRBG" );

--- a/src/pkcs11/dev_mode_key_provisioning/dev_mode_key_provisioning.c
+++ b/src/pkcs11/dev_mode_key_provisioning/dev_mode_key_provisioning.c
@@ -470,7 +470,7 @@ CK_RV xProvisionPublicKey( CK_SESSION_HANDLE xSession,
         xPublicKeyTemplate[ 0 ].pValue = &xClass;
         xPublicKeyTemplate[ 1 ].pValue = &xPublicKeyType;
         xPublicKeyTemplate[ 2 ].pValue = &xTrue;
-        xPublicKeyTemplate[ 3 ].pValue = &xModulus + 1;
+        xPublicKeyTemplate[ 3 ].pValue = &xModulus[ 1 ];
         xPublicKeyTemplate[ 4 ].pValue = &xTrue;
         xPublicKeyTemplate[ 5 ].pValue = xPublicExponent;
 

--- a/src/pkcs11/rsa_test_credentials.h
+++ b/src/pkcs11/rsa_test_credentials.h
@@ -66,29 +66,41 @@
     "YZ4lIW5sJLATES9+Z8nHi7yRDLw6x/kcVQIDAQAB\n"                         \
     "-----END RSA PUBLIC KEY-----\n"
 
+#if ( PKCS11_TEST_PREPROVISIONED_SUPPORT != 0 ) && ( PKCS11_TEST_RSA_KEY_SUPPORT != 0 )
+    #ifndef PKCS11_TEST_RSA_CERTIFICATE
+        #error "PKCS11_TEST_RSA_CERTIFICATE must be defined to verify RSA preprovision mechanism."
+    #endif
+    #ifndef PKCS11_TEST_RSA_CERTIFICATE_LENGTH
+        #error "PKCS11_TEST_RSA_CERTIFICATE_LENGTH must be defined to verify RSA preprovision mechanism."
+    #endif
 
-#define RSA_TEST_VALID_CERTIFICATE                                       \
-    "-----BEGIN CERTIFICATE-----\n"                                      \
-    "MIIDsTCCApmgAwIBAgIJALg4YJlPspxyMA0GCSqGSIb3DQEBCwUAMG8xCzAJBgNV\n" \
-    "BAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTENMAsGA1UECgwE\n" \
-    "QW16bjEMMAoGA1UECwwDSW9UMQ0wCwYDVQQDDARUZXN0MRUwEwYJKoZIhvcNAQkB\n" \
-    "FgZub2JvZHkwHhcNMTgwNjExMTk0NjM2WhcNMjEwMzMxMTk0NjM2WjBvMQswCQYD\n" \
-    "VQQGEwJVUzELMAkGA1UECAwCV0ExEDAOBgNVBAcMB1NlYXR0bGUxDTALBgNVBAoM\n" \
-    "BEFtem4xDDAKBgNVBAsMA0lvVDENMAsGA1UEAwwEVGVzdDEVMBMGCSqGSIb3DQEJ\n" \
-    "ARYGbm9ib2R5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsIqRecRx\n" \
-    "Lz3PZXzZOHF7jMlB25tfv2LDGR7nGTJiey5zxd7oswihe7+26yx8medpNvX1ym9j\n" \
-    "phty+9IR053k1WGnQQ4aaDeJonqn7V50Vesw6zFx/x8LMdXFoBAkRXIL8WS5YKaf\n" \
-    "C87KPnye8A0piVWUFy7+IEEaK3hQEJTzB6LC/N100XL5ykLCa4xJBOqlIvbDvJ+b\n" \
-    "Kty1EBA3sStlTNuXi3nBWZbXwCB2A+ddjijFf5+gUjinr7h6e2uQeipWyiIw9NKW\n" \
-    "bvq8AG1Mj4XBoFL9wP2YTf2SQAgAzx0ySPNrIYOzBNl1YZ4lIW5sJLATES9+Z8nH\n" \
-    "i7yRDLw6x/kcVQIDAQABo1AwTjAdBgNVHQ4EFgQUHc4PjEL0CaxZ+1D/4VdeDjxt\n" \
-    "JO8wHwYDVR0jBBgwFoAUHc4PjEL0CaxZ+1D/4VdeDjxtJO8wDAYDVR0TBAUwAwEB\n" \
-    "/zANBgkqhkiG9w0BAQsFAAOCAQEAi1/okTpQuPcaQEBgepccZ/Lt/gEQNdGcbsYQ\n" \
-    "3aEABNVYL8dYOW9r/8l074zD+vi9iSli/yYmwRFD0baN1FRWUqkVEIQ+3yfivOW9\n" \
-    "R282NuQvEULgERC2KN7vm0vO+DF7ay58qm4PaAGHdQco1LaHKkljMPLHF841facG\n" \
-    "M9KVtzFveOQKkWvb4VgOyfn7aCnEogGlWt1S0d12pBRwYjJgKrVQaGs6IiGFVtm8\n" \
-    "JRLZrLL3sfgsN7L1xu//JUoTOkgxdKuYRmPuUdV2hw/VYDzcnKj7/DMXNDvgl3s7\n" \
-    "5GC4F+8LFLzRrZJWs18FMLaCE+zJChw/oeSt+RS0JZDFn+uX9Q==\n"             \
-    "-----END CERTIFICATE-----\n"
+    #define RSA_TEST_VALID_CERTIFICATE PKCS11_TEST_RSA_CERTIFICATE
+    #define RSA_TEST_VALID_CERTIFICATE_LENGTH PKCS11_TEST_RSA_CERTIFICATE_LENGTH
+#else
+    #define RSA_TEST_VALID_CERTIFICATE                                       \
+        "-----BEGIN CERTIFICATE-----\n"                                      \
+        "MIIDsTCCApmgAwIBAgIJALg4YJlPspxyMA0GCSqGSIb3DQEBCwUAMG8xCzAJBgNV\n" \
+        "BAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTENMAsGA1UECgwE\n" \
+        "QW16bjEMMAoGA1UECwwDSW9UMQ0wCwYDVQQDDARUZXN0MRUwEwYJKoZIhvcNAQkB\n" \
+        "FgZub2JvZHkwHhcNMTgwNjExMTk0NjM2WhcNMjEwMzMxMTk0NjM2WjBvMQswCQYD\n" \
+        "VQQGEwJVUzELMAkGA1UECAwCV0ExEDAOBgNVBAcMB1NlYXR0bGUxDTALBgNVBAoM\n" \
+        "BEFtem4xDDAKBgNVBAsMA0lvVDENMAsGA1UEAwwEVGVzdDEVMBMGCSqGSIb3DQEJ\n" \
+        "ARYGbm9ib2R5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsIqRecRx\n" \
+        "Lz3PZXzZOHF7jMlB25tfv2LDGR7nGTJiey5zxd7oswihe7+26yx8medpNvX1ym9j\n" \
+        "phty+9IR053k1WGnQQ4aaDeJonqn7V50Vesw6zFx/x8LMdXFoBAkRXIL8WS5YKaf\n" \
+        "C87KPnye8A0piVWUFy7+IEEaK3hQEJTzB6LC/N100XL5ykLCa4xJBOqlIvbDvJ+b\n" \
+        "Kty1EBA3sStlTNuXi3nBWZbXwCB2A+ddjijFf5+gUjinr7h6e2uQeipWyiIw9NKW\n" \
+        "bvq8AG1Mj4XBoFL9wP2YTf2SQAgAzx0ySPNrIYOzBNl1YZ4lIW5sJLATES9+Z8nH\n" \
+        "i7yRDLw6x/kcVQIDAQABo1AwTjAdBgNVHQ4EFgQUHc4PjEL0CaxZ+1D/4VdeDjxt\n" \
+        "JO8wHwYDVR0jBBgwFoAUHc4PjEL0CaxZ+1D/4VdeDjxtJO8wDAYDVR0TBAUwAwEB\n" \
+        "/zANBgkqhkiG9w0BAQsFAAOCAQEAi1/okTpQuPcaQEBgepccZ/Lt/gEQNdGcbsYQ\n" \
+        "3aEABNVYL8dYOW9r/8l074zD+vi9iSli/yYmwRFD0baN1FRWUqkVEIQ+3yfivOW9\n" \
+        "R282NuQvEULgERC2KN7vm0vO+DF7ay58qm4PaAGHdQco1LaHKkljMPLHF841facG\n" \
+        "M9KVtzFveOQKkWvb4VgOyfn7aCnEogGlWt1S0d12pBRwYjJgKrVQaGs6IiGFVtm8\n" \
+        "JRLZrLL3sfgsN7L1xu//JUoTOkgxdKuYRmPuUdV2hw/VYDzcnKj7/DMXNDvgl3s7\n" \
+        "5GC4F+8LFLzRrZJWs18FMLaCE+zJChw/oeSt+RS0JZDFn+uX9Q==\n"             \
+        "-----END CERTIFICATE-----\n"
+    #define RSA_TEST_VALID_CERTIFICATE_LENGTH    ( 949 )
+#endif
 
 #endif /* ifndef RSA_TEST_CREDENTIALS_H */

--- a/src/pkcs11/rsa_test_credentials.h
+++ b/src/pkcs11/rsa_test_credentials.h
@@ -66,18 +66,8 @@
     "YZ4lIW5sJLATES9+Z8nHi7yRDLw6x/kcVQIDAQAB\n"                         \
     "-----END RSA PUBLIC KEY-----\n"
 
-#if ( PKCS11_TEST_PREPROVISIONED_SUPPORT != 0 ) && ( PKCS11_TEST_RSA_KEY_SUPPORT != 0 )
-    #ifndef PKCS11_TEST_RSA_CERTIFICATE
-        #error "PKCS11_TEST_RSA_CERTIFICATE must be defined to verify RSA preprovision mechanism."
-    #endif
-    #ifndef PKCS11_TEST_RSA_CERTIFICATE_LENGTH
-        #error "PKCS11_TEST_RSA_CERTIFICATE_LENGTH must be defined to verify RSA preprovision mechanism."
-    #endif
-
-    #define RSA_TEST_VALID_CERTIFICATE PKCS11_TEST_RSA_CERTIFICATE
-    #define RSA_TEST_VALID_CERTIFICATE_LENGTH PKCS11_TEST_RSA_CERTIFICATE_LENGTH
-#else
-    #define RSA_TEST_VALID_CERTIFICATE                                       \
+#ifndef PKCS11_TEST_RSA_CERTIFICATE
+    #define PKCS11_TEST_RSA_CERTIFICATE                                      \
         "-----BEGIN CERTIFICATE-----\n"                                      \
         "MIIDsTCCApmgAwIBAgIJALg4YJlPspxyMA0GCSqGSIb3DQEBCwUAMG8xCzAJBgNV\n" \
         "BAYTAlVTMQswCQYDVQQIDAJXQTEQMA4GA1UEBwwHU2VhdHRsZTENMAsGA1UECgwE\n" \
@@ -99,8 +89,13 @@
         "M9KVtzFveOQKkWvb4VgOyfn7aCnEogGlWt1S0d12pBRwYjJgKrVQaGs6IiGFVtm8\n" \
         "JRLZrLL3sfgsN7L1xu//JUoTOkgxdKuYRmPuUdV2hw/VYDzcnKj7/DMXNDvgl3s7\n" \
         "5GC4F+8LFLzRrZJWs18FMLaCE+zJChw/oeSt+RS0JZDFn+uX9Q==\n"             \
-        "-----END CERTIFICATE-----\n"
-    #define RSA_TEST_VALID_CERTIFICATE_LENGTH    ( 949 )
+    "-----END CERTIFICATE-----\n"
 #endif
+#ifndef PKCS11_TEST_RSA_CERTIFICATE_LENGTH
+    #define PKCS11_TEST_RSA_CERTIFICATE_LENGTH    ( 949 )
+#endif
+
+#define RSA_TEST_VALID_CERTIFICATE PKCS11_TEST_RSA_CERTIFICATE
+#define RSA_TEST_VALID_CERTIFICATE_LENGTH PKCS11_TEST_RSA_CERTIFICATE_LENGTH
 
 #endif /* ifndef RSA_TEST_CREDENTIALS_H */


### PR DESCRIPTION
The tested platform may already be pre-provisioned with keys other than those provided in the test. The PKCS11_RSA_GetAttributeValue test may fail to verify the RSA pre-provisioning mechanism under this scenario.

In this PR:
* Add `PKCS11_TEST_RSA_CERTIFICATE` and `PKCS11_TEST_RSA_CERTIFICATE_TEST` for platform with preprovisioned RSA key.
* Since the preprovisioned certificate is also provided int the test through these two macros. We can also verify the certificate acquired through pkcs11 API is the same as the certificate pre-provisioned now. The condition to check provision method is removed.

-----------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
