### PR TITLE
Introduce user defined MQTT keep alive value

### DIFF
--- a/src/mqtt/mqtt_test.c
+++ b/src/mqtt/mqtt_test.c
@@ -170,7 +170,9 @@
  * @brief Time interval in seconds at which an MQTT PINGREQ need to be sent to
  * broker.
  */
-#define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 5U )
+#ifndef MQTT_KEEP_ALIVE_INTERVAL_SECONDS
+    #define MQTT_KEEP_ALIVE_INTERVAL_SECONDS    ( 5U )
+#endif
 
 /**
  * @brief The MQTT message published in this example.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`MQTT_KEEP_ALIVE_INTERVAL_SECONDS` macro value depends on the responsiveness of the target running the tests because some targets might be faster or slower than others. Hence, it would be useful to have a default value for this macro (5) and the integration code can provide other value if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
